### PR TITLE
Updates the hardware installation to use OAI helm charts

### DIFF
--- a/install.md
+++ b/install.md
@@ -263,11 +263,11 @@ images:
     hssdb: docker.io/onosproject/riab-hssdb:v1.0.0
     hss: docker.io/onosproject/riab-hss:v1.0.0
     mme: docker.io/onosproject/riab-nucleus-mme:v1.0.0
-    spgwc: docker.io/onosproject/riab-spgw:v1.0.0-onfvm-1
+    spgwc: docker.io/onosproject/riab-spgw:v1.0.0
     pcrf: docker.io/onosproject/riab-pcrf:v1.0.0
     pcrfdb: docker.io/onosproject/riab-pcrfdb:v1.0.0
-    bess: docker.io/onosproject/riab-bess-upf:v1.0.0-onfvm-1
-    pfcpiface: docker.io/onosproject/riab-pfcpiface:v1.0.0-onfvm-1
+    bess: docker.io/onosproject/riab-bess-upf:v1.0.0
+    pfcpiface: docker.io/onosproject/riab-pfcpiface:v1.0.0
 # For OAI
     oaicucp: docker.io/onosproject/oai-enb-cu:latest
     oaidu: docker.io/onosproject/oai-enb-du:latest


### PR DESCRIPTION
Defines how to use helm charts to run oai components in the
hardware installation, and their specified docker images.
I.e., no longer depends on compiling oai.
Previous docs were kept in the topic baremetal installation.