### PR TITLE
Adds monitoring/logging docs to RiaB installation

### DIFF
--- a/riab_install_index.rst
+++ b/riab_install_index.rst
@@ -12,5 +12,6 @@ sdRan-in-a-Box
    sdran-in-a-box/docs/Installation_OAI_nFAPI
    sdran-in-a-box/docs/Installation_RANSim_PCI
    sdran-in-a-box/docs/Installation_RANSim_FBAH
+   sdran-in-a-box/docs/Installation_mon_logs
    sdran-in-a-box/docs/Troubleshooting
 


### PR DESCRIPTION
Docs describe how to setup prometheus/grafana and EFK stack to
see logs and metrics associated with RiaB components.